### PR TITLE
style: fix formatting using `rustfmt`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -9,13 +9,3 @@ use_small_heuristics = "Default"
 reorder_imports = true
 reorder_modules = true
 remove_nested_parens = true
-format_strings = true
-format_macro_matchers = true
-format_macro_bodies = true
-normalize_comments = true
-normalize_doc_attributes = true
-wrap_comments = true
-comment_width = 80
-imports_granularity = "Crate"
-group_imports = "StdExternalCrate"
-

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,13 +4,13 @@
 //! authentication, request/response processing, and error handling.
 
 use crate::{
+    Result,
     config::Config,
     http::HttpClient,
     resources::{
         BillingStatements, CheckoutSessions, Customers, Events, PaymentIntents, Payments, Payouts,
         Refunds, Webhooks,
     },
-    Result,
 };
 use std::sync::Arc;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@
 //! This module provides configuration options for customizing the behavior
 //! of the PayRex client, including timeouts, retries, and API endpoints.
 
-use crate::{Error, Result, API_BASE_URL};
+use crate::{API_BASE_URL, Error, Result};
 use std::time::Duration;
 
 /// Configuration for the PayRex client.

--- a/src/http.rs
+++ b/src/http.rs
@@ -4,8 +4,8 @@
 //! rate limiting, and proper error handling for the PayRex API.
 
 use crate::{Config, Error, ErrorKind, Result};
-use reqwest::{header, Client as ReqwestClient, RequestBuilder, Response, StatusCode};
-use serde::{de::DeserializeOwned, Serialize};
+use reqwest::{Client as ReqwestClient, RequestBuilder, Response, StatusCode, header};
+use serde::{Serialize, de::DeserializeOwned};
 use std::time::Duration;
 
 /// HTTP client for making requests to the PayRex API.

--- a/src/resources/billing_statements.rs
+++ b/src/resources/billing_statements.rs
@@ -3,9 +3,9 @@
 //! Billing Statements allow you to create and send invoices to customers.
 
 use crate::{
+    Result,
     http::HttpClient,
     types::{BillingStatementId, Currency, CustomerId, List, ListParams, Metadata, Timestamp},
-    Result,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/src/resources/checkout_sessions.rs
+++ b/src/resources/checkout_sessions.rs
@@ -3,9 +3,9 @@
 //! Checkout Sessions create a hosted payment page for collecting payment.
 
 use crate::{
+    Result,
     http::HttpClient,
     types::{CheckoutSessionId, Currency, Metadata, Timestamp},
-    Result,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/src/resources/customers.rs
+++ b/src/resources/customers.rs
@@ -4,9 +4,9 @@
 //! multiple payments and billing information.
 
 use crate::{
+    Result,
     http::HttpClient,
     types::{Currency, CustomerId, List, ListParams, Metadata, Timestamp},
-    Result,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/src/resources/events.rs
+++ b/src/resources/events.rs
@@ -3,9 +3,9 @@
 //! Events represent changes to resources in your account.
 
 use crate::{
+    Result,
     http::HttpClient,
     types::{EventId, List, ListParams, Timestamp},
-    Result,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/src/resources/payment_intents.rs
+++ b/src/resources/payment_intents.rs
@@ -4,9 +4,9 @@
 //! They track the lifecycle of a payment from creation through completion.
 
 use crate::{
+    Result,
     http::HttpClient,
     types::{Currency, Metadata, PaymentIntentId, Timestamp},
-    Result,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/src/resources/payments.rs
+++ b/src/resources/payments.rs
@@ -3,9 +3,9 @@
 //! Payments represent successful payment transactions.
 
 use crate::{
+    Result,
     http::HttpClient,
     types::{Currency, Metadata, PaymentId, PaymentIntentId, Timestamp},
-    Result,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/src/resources/payouts.rs
+++ b/src/resources/payouts.rs
@@ -3,9 +3,9 @@
 //! Payouts represent transfers of funds to your bank account.
 
 use crate::{
+    Result,
     http::HttpClient,
     types::{List, ListParams, PayoutId, Timestamp},
-    Result,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/src/resources/refunds.rs
+++ b/src/resources/refunds.rs
@@ -3,9 +3,9 @@
 //! Refunds allow you to return money to a customer.
 
 use crate::{
+    Result,
     http::HttpClient,
     types::{Currency, Metadata, PaymentId, RefundId, Timestamp},
-    Result,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/src/resources/webhooks.rs
+++ b/src/resources/webhooks.rs
@@ -3,9 +3,9 @@
 //! Webhooks allow you to receive real-time notifications about events.
 
 use crate::{
+    Result,
     http::HttpClient,
     types::{List, ListParams, Timestamp, WebhookId},
-    Result,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;


### PR DESCRIPTION
Fixes formatting errors from `rustfmt`.
Use `cargo fmt --all -- --check`