### PR TITLE
fix: make fields non-optional

### DIFF
--- a/src/resources/billing_statements.rs
+++ b/src/resources/billing_statements.rs
@@ -110,8 +110,7 @@ pub struct BillingStatement {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub customer: Option<Metadata>,
     pub created_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<Timestamp>,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/resources/checkout_sessions.rs
+++ b/src/resources/checkout_sessions.rs
@@ -70,8 +70,7 @@ pub struct CheckoutSession {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<Timestamp>,
     pub created_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<Timestamp>,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/resources/customers.rs
+++ b/src/resources/customers.rs
@@ -64,8 +64,7 @@ pub struct Customer {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_billing_statement_sequence_number: Option<i64>,
     pub created_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<Timestamp>,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src/resources/events.rs
+++ b/src/resources/events.rs
@@ -42,6 +42,5 @@ pub struct Event {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub previous_attributes: Option<Value>,
     pub created_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<Timestamp>,
+    pub updated_at: Timestamp,
 }

--- a/src/resources/payment_intents.rs
+++ b/src/resources/payment_intents.rs
@@ -114,12 +114,9 @@ pub struct PaymentError {
 pub struct PaymentIntent {
     pub id: PaymentIntentId,
     pub amount: i64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub amount_received: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub amount_capturable: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_secret: Option<String>,
+    pub amount_received: i64,
+    pub amount_capturable: i64,
+    pub client_secret: String,
     pub currency: Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -132,12 +129,10 @@ pub struct PaymentIntent {
     pub last_payment_error: Option<PaymentError>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_method_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub payment_methods: Option<Vec<String>>,
+    pub payment_methods: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_method_options: Option<PaymentMethodOptions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor: Option<String>,
+    pub statement_descriptor: String,
     pub status: PaymentIntentStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<NextAction>,
@@ -146,8 +141,7 @@ pub struct PaymentIntent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capture_before_at: Option<Timestamp>,
     pub created_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<Timestamp>,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/resources/payments.rs
+++ b/src/resources/payments.rs
@@ -36,31 +36,25 @@ impl Payments {
 pub struct Payment {
     pub id: PaymentId,
     pub amount: i64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub amount_refunded: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub billing: Option<Metadata>,
+    pub amount_refunded: i64,
+    pub billing: Metadata, // TODO: add Billing type
     pub currency: Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fee: Option<i64>,
+    pub fee: i64,
     pub livemode: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub net_amount: Option<i64>,
+    pub net_amount: i64,
     pub payment_intent_id: PaymentIntentId,
     pub status: PaymentStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub customer: Option<Metadata>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_method: Option<Metadata>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub refunded: Option<bool>,
+    pub refunded: bool,
     pub created_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<Timestamp>,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/resources/payouts.rs
+++ b/src/resources/payouts.rs
@@ -41,7 +41,6 @@ pub struct Payout {
     pub net_amount: Option<i64>,
     pub status: PayoutStatus,
     pub created_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<Timestamp>,
 }
 

--- a/src/resources/refunds.rs
+++ b/src/resources/refunds.rs
@@ -41,16 +41,14 @@ pub struct Refund {
     pub status: RefundStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
+    pub reason: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remarks: Option<String>,
     pub payment_id: PaymentId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
     pub created_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<Timestamp>,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -66,8 +64,7 @@ pub enum RefundStatus {
 pub struct CreateRefund {
     pub payment: PaymentId,
     pub amount: i64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
+    pub reason: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
 }

--- a/src/resources/webhooks.rs
+++ b/src/resources/webhooks.rs
@@ -70,8 +70,7 @@ pub struct Webhook {
     pub url: String,
     pub events: Vec<String>,
     pub created_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<Timestamp>,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Turns some fields that were mistakenly optional into non-optional fields. Some fields are still optional but I took care of most of the low-hanging fruits.