### PR TITLE
docs: add documentation for payment intents

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+doc-valid-idents = [
+    "GCash",
+    "PayRex",
+]

--- a/src/resources/payment_intents.rs
+++ b/src/resources/payment_intents.rs
@@ -12,6 +12,10 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Clone)]
+/// A [`PaymentIntent`] tracks the customer's payment lifecycle, keeping track of any failed payment
+/// attempts and ensuring the customer is only charged once. Create one [`PaymentIntent`] whenever your
+/// customer arrives at your checkout page. Retrieve the Payment Intent later to see the history of
+/// payment attempts.
 pub struct PaymentIntents {
     http: Arc<HttpClient>,
 }
@@ -22,22 +26,43 @@ impl PaymentIntents {
         Self { http }
     }
 
+    /// Creates a [`PaymentIntent`] resource.
+    ///
+    /// Endpoint: `POST /payment_intents`
+    ///
+    /// [API Reference](https://docs.payrexhq.com/docs/api/payment_intents/create)
     pub async fn create(&self, params: CreatePaymentIntent) -> Result<PaymentIntent> {
         self.http.post("/payment_intents", &params).await
     }
 
+    /// Retrieve a [`PaymentIntent`] resource by ID.
+    ///
+    /// Endpoint: `GET /payment_intents/:id`
+    ///
+    /// [API Reference](https://docs.payrexhq.com/docs/api/payment_intents/retrieve)
     pub async fn retrieve(&self, id: &PaymentIntentId) -> Result<PaymentIntent> {
         self.http
             .get(&format!("/payment_intents/{}", id.as_str()))
             .await
     }
 
+    /// Cancels a [`PaymentIntent`] resource. A payment intent with a status of `canceled` means your
+    /// customer cannot proceed with paying the particular payment intent.
+    ///
+    /// Endpoint: `POST /payment_intents/:id/cancel`
+    ///
+    /// [API Reference](https://docs.payrexhq.com/docs/api/payment_intents/cancel)
     pub async fn cancel(&self, id: &PaymentIntentId) -> Result<PaymentIntent> {
         self.http
             .post(&format!("/payment_intents/{}/cancel", id.as_str()), &())
             .await
     }
 
+    /// Captures a [`PaymentIntent`] resource.
+    ///
+    /// Endpoint: `POST /payment_intents/:id/capture`
+    ///
+    /// [API Reference](https://docs.payrexhq.com/docs/api/payment_intents/capture)
     pub async fn capture(
         &self,
         id: &PaymentIntentId,
@@ -52,19 +77,28 @@ impl PaymentIntents {
     }
 }
 
+/// Available payment methods for a [`PaymentIntent`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PaymentMethod {
+    /// Card payments
     #[serde(rename = "card")]
     Card,
+
+    /// GCash payments
     #[serde(rename = "gcash")]
     GCash,
+
+    /// Maya payments
     #[serde(rename = "maya")]
     Maya,
+
+    /// QRPH payments
     #[serde(rename = "qrph")]
     QRPh,
 }
 
 impl PaymentMethod {
+    /// Returns the string representation of the payment method.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -76,119 +110,287 @@ impl PaymentMethod {
     }
 }
 
+/// A set of key-value pairs that can modify the behavior of the payment method attached to the
+/// payment intent.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PaymentMethodOptions {
+    /// Hash of options for the `card` payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub card: Option<CardOptions>,
 }
 
+/// Hash of options for the `card` payment method.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CardOptions {
+    /// Describes the `capture_type` of a card payment. Possible values are `automatic` or
+    /// `manual`. This is used for hold then capture feature. Please refer to this
+    /// [guide](https://docs.payrexhq.com/docs/guide/developer_handbook/payments/payment_methods/card/hold_then_capture)
+    /// for more details.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capture_type: Option<CaptureMethod>,
+
+    /// Restricts the allowed card BINs for a card payment. Please refer to this
+    /// [guide](https://docs.payrexhq.com/docs/guide/developer_handbook/payments/payment_methods/card/allowed_bins)
+    /// for more details.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_bins: Option<Vec<String>>,
+
+    /// Restricts the allowed card funding for a card payment. Please refer to this
+    /// [guide](https://docs.payrexhq.com/docs/guide/developer_handbook/payments/payment_methods/card/allowed_funding)
+    /// for more details.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_funding: Option<Vec<String>>,
 }
 
+/// If this attribute is present, it tells you what actions you need to take so that your customer
+/// can make a payment using the selected method.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NextAction {
+    /// The type of the next action to perform, The possible value is `redirect`.
     #[serde(rename = "type")]
     pub action_type: String,
+
+    /// The URL for authenticating a payment by redirecting your customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redirect_url: Option<String>,
 }
 
+/// The error code returned in case of a failed payment attempt.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PaymentError {
+    /// The status code of the error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
+
+    /// A message that provides more details about the error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+
+    /// If the error is parameter-specific, the parameter related to the error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub param: Option<String>,
 }
 
+/// A [`PaymentIntent`] tracks the customer's payment lifecycle, keeping track of any failed payment attempts and ensuring the customer is only charged once. Create one [`PaymentIntent`] whenever your customer arrives at your checkout page. Retrieve the Payment Intent later to see the history of payment attempts.
+///
+/// A [`PaymentIntent`] transitions through multiple statuses throughout its lifetime via Payrex.JS until it creates, at most, one successful payment.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PaymentIntent {
+    /// Unique identifier for the resource. The prefix is `pi_`.
     pub id: PaymentIntentId,
+
+    /// The amount to be collected by the [`PaymentIntent`]. This is a positive integer that your
+    /// customer will pay in the smallest currency unit, cents. If the customer should pay ₱
+    /// 120.50, the amount of the [`PaymentIntent`] should be 12050.
+    ///
+    /// The minimum amount is ₱ 20 (2000 in cents) and the maximum amount is ₱ 59,999,999.99
+    /// (5999999999 in cents).
     pub amount: i64,
+
+    /// The amount already collected by the [`PaymentIntent`]. This is a positive integer that your
+    /// customer paid in the smallest currency unit, cents. If the customer paid ₱ 120.50, the
+    /// `amount_received` of the [`PaymentIntent`] should be 12050.
+    ///
+    /// The minimum amount is ₱ 20 (2000 in cents) and the maximum amount is ₱ 59,999,999.99
+    /// (5999999999 in cents).
     pub amount_received: i64,
+
+    /// The amount that can be captured by the [`PaymentIntent`]. This is a positive integer that your
+    /// customer authorized in the smallest currency unit, cents. If the customer authorized ₱
+    /// 120.50, the `amount_capturable` of the [`PaymentIntent`] should be 12050.
+    ///
+    /// The minimum amount is ₱ 20 (2000 in cents) and the maximum amount is ₱ 59,999,999.99
+    /// (5999999999 in cents).
     pub amount_capturable: i64,
+
+    ///The client secret of this [`PaymentIntent`] used for client-side retrieval using a public API
+    ///key. The client secret can be used to complete a payment from your client application.
     pub client_secret: String,
+
+    /// A three-letter ISO currency code in uppercase. As of the moment, we only support PHP.
     pub currency: Currency,
+
+    /// An arbitrary string attached to the [`PaymentIntent`]. Useful reference when viewing paid
+    /// Payment from PayRex Dashboard.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// The value is `true` if the resource's mode is live or the value is `false` if the resource mode is test.
     pub livemode: bool,
+
+    /// A set of key-value pairs attached to the [`PaymentIntent`] and the resources created by the
+    /// [`PaymentIntent`], e.g., Payment. This is useful for storing additional information about the
+    /// [`PaymentIntent`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
+
+    /// The `Payment` ID of the latest successful payment created by the [`PaymentIntent`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub latest_payment: Option<String>,
+
+    /// The error returned in case of a failed payment attempt.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_payment_error: Option<PaymentError>,
+
+    /// The latest `PaymentMethod` ID of attached to the [`PaymentIntent`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_method_id: Option<String>,
+
+    /// The list of payment methods allowed to be processed by the [`PaymentIntent`].
     pub payment_methods: Vec<String>,
+
+    /// A set of key-value pairs that can modify the behavior of the payment method attached to the
+    /// payment intent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_method_options: Option<PaymentMethodOptions>,
+
+    /// Text that appears on the customer's bank statement. This value overrides the merchant
+    /// account's trade name. For information about requirements, including the 22-character limit,
+    /// see the [Statement
+    /// Descriptor](https://docs.payrexhq.com/docs/guide/developer_handbook/statement_descriptor)
+    /// guide.
     pub statement_descriptor: String,
+
+    /// The latest status of the [`PaymentIntent`]. Possible values are `awaiting_payment_method`, `awaiting_next_action`, `processing`, or `succeeded`.
     pub status: PaymentIntentStatus,
+
+    /// If this attribute is present, it tells you what actions you need to take so that your
+    /// customer can make a payment using the selected method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<NextAction>,
+
+    /// The URL where your customer will be redirected after completing the authentication if they
+    /// didn't exit or close their browser while authenticating.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub return_url: Option<String>,
+
+    /// The time by which the [`PaymentIntent`] must be captured to avoid being canceled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capture_before_at: Option<Timestamp>,
+
+    /// The time the resource was created and measured in seconds since the Unix epoch.
     pub created_at: Timestamp,
+
+    /// The time the resource was updated and measured in seconds since the Unix epoch.
     pub updated_at: Timestamp,
 }
 
+/// The status of a [`PaymentIntent`] describes the current state of the payment process.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PaymentIntentStatus {
+    /// Awaiting a valid payment method to be attached.
     AwaitingPaymentMethod,
+
+    /// The payment requires a payment method.
     RequiresPaymentMethod,
+
+    /// The payment requires confirmation before proceeding.
     RequiresConfirmation,
+
+    /// The payment requires further action before proceeding.
     RequiresAction,
+
+    /// The payment is being processed.
     Processing,
+
+    /// The payment requires capture.
     RequiresCapture,
+
+    /// The payment was cancelled.
     Cancelled,
+
+    /// The payment was successful.
     Succeeded,
 }
 
+/// Query parameters when creating a payment intent.
+///
+/// [Reference](https://docs.payrexhq.com/docs/api/payment_intents/create#parameters)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreatePaymentIntent {
+    /// The amount to be collected by the [`PaymentIntent`]. This is a positive integer your customer
+    /// will pay in the smallest currency unit, cents. If the customer should pay ₱ 120.50, the
+    /// amount of the [`PaymentIntent`] should be 12050.
+    ///
+    /// The minimum amount is ₱ 20 (2000 in cents) and the maximum amount is ₱ 59,999,999.99
+    /// (5999999999 in cents).
     pub amount: i64,
+
+    /// A three-letter ISO currency code in uppercase. As of the moment, we only support PHP.
     pub currency: Currency,
+
+    /// The list of payment methods allowed to be processed by the [`PaymentIntent`]. Possible values
+    /// are `card`, `gcash`, `maya`, and `qrph`.
     pub payment_methods: Vec<PaymentMethod>,
+
+    /// An arbitrary string attached to the [`PaymentIntent`]. Useful reference when viewing paid
+    /// Payment from PayRex Dashboard.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// A set of key-value pairs you can attach to the [`PaymentIntent`] and the resources created by
+    /// the [`PaymentIntent`] e.g. Payment. This can be useful for storing additional information about
+    /// the [`PaymentIntent`] in a hash format.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
+
+    /// Describes the `capture_method` of a card payment. Possible values are `automatic` or
+    /// `manual`. This is used for hold then capture feature. Please refer to this
+    /// [guide](https://docs.payrexhq.com/docs/guide/developer_handbook/payments/payment_methods/card/hold_then_capture)
+    /// for more details.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capture_method: Option<CaptureMethod>,
+
+    /// A set of key-value pairs that can modify the behavior of the payment method attached to the
+    /// payment intent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_method_options: Option<PaymentMethodOptions>,
+
+    /// Text that appears on the customer's bank statement. This value overrides the merchant
+    /// account's trade name. For information about requirements, including the 22-character limit,
+    /// see the [Statement
+    /// Descriptor](https://docs.payrexhq.com/docs/guide/developer_handbook/statement_descriptor)
+    /// guide.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub statement_descriptor: Option<String>,
+
+    /// The URL where your customer will be redirected after completing the authentication if they
+    /// didn't exit or close their browser while authenticating.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub return_url: Option<String>,
 }
 
+/// Describes the `capture_method` of a card payment. Possible values are `automatic` or
+/// `manual`. This is used for hold then capture feature. Please refer to this
+/// [guide](https://docs.payrexhq.com/docs/guide/developer_handbook/payments/payment_methods/card/hold_then_capture)
+/// for more details.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CaptureMethod {
+    /// The payment is captured automatically.
     Automatic,
+
+    /// The payment requires manual capture.
     Manual,
 }
 
+/// Query parameters when capturing a payment intent.
+///
+/// [Reference](https://docs.payrexhq.com/docs/api/payment_intents/capture#parameters)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CapturePaymentIntent {
+    /// The amount to be captured by the [`PaymentIntent`]. This is a positive integer that your
+    /// customer authorized in the smallest currency unit, cents. If the customer should pay ₱
+    /// 120.50, the amount of the [`PaymentIntent`] should be 12050.
+    ///
+    /// The minimum amount is ₱ 20 (2000 in cents), and the maximum amount is ₱ 59,999,999.99
+    /// (5999999999 in cents).
     pub amount: i64,
 }
 
 impl CapturePaymentIntent {
+    /// Creates a new [`CapturePaymentIntent`] with the specified amount.
     #[must_use]
     pub const fn new(amount: i64) -> Self {
         Self { amount }
@@ -196,6 +398,8 @@ impl CapturePaymentIntent {
 }
 
 impl CreatePaymentIntent {
+    /// Creates a new [`CreatePaymentIntent`] with the specified amount, currency, and payment
+    /// methods.
     #[must_use]
     pub fn new(amount: i64, currency: Currency, payment_methods: &[PaymentMethod]) -> Self {
         Self {
@@ -211,36 +415,42 @@ impl CreatePaymentIntent {
         }
     }
 
+    /// Sets the description.
     #[must_use]
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
     }
 
+    /// Sets the metadata.
     #[must_use]
     pub fn metadata(mut self, metadata: Metadata) -> Self {
         self.metadata = Some(metadata);
         self
     }
 
+    /// Sets the capture method.
     #[must_use]
     pub const fn capture_method(mut self, method: CaptureMethod) -> Self {
         self.capture_method = Some(method);
         self
     }
 
+    /// Sets the payment method options.
     #[must_use]
     pub fn payment_method_options(mut self, options: PaymentMethodOptions) -> Self {
         self.payment_method_options = Some(options);
         self
     }
 
+    /// Sets the statement descriptor.
     #[must_use]
     pub fn statement_descriptor(mut self, descriptor: impl Into<String>) -> Self {
         self.statement_descriptor = Some(descriptor.into());
         self
     }
 
+    /// Sets the return URL.
     #[must_use]
     pub fn return_url(mut self, url: impl Into<String>) -> Self {
         self.return_url = Some(url.into());


### PR DESCRIPTION
Add documentation for payment intents. This also includes adding keywords that clippy can safely be ignored for `doc_markdown`.