### PR TITLE
feat: implement refunds api

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Unofficial Rust SDK for [PayRex](https://payrexhq.com)
   - [ ] Checkout Sessions
   - [ ] Webhooks
   - [ ] Events
-  - [ ] Refunds
+  - [x] Refunds
   - [x] Payouts
 - [ ] Final
   - [ ] Integration tests


### PR DESCRIPTION
Checklist:
- [x] Add `RefundReason` enum
- [x] Implement setters for `CreateRefund` struct
- [x] Add unit test for serializing `Refund`
- [x] Add unit test for serializing `RefundStatus`
- [x] Add unit test for serializing `RefundReason`
- [x] Add unit test for serializing `UpdateRefund`
- [x] Add unit test for setters in `CreateRefund`
- [x] Update README.md to complete Refunds API