### PR TITLE
feat: implement billing statements api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tokio-test",
  "url",
@@ -1028,7 +1028,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -1049,7 +1049,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1361,13 +1361,12 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
+version = "0.15.0"
+source = "git+https://github.com/Sheape/serde_qs.git?branch=array-support#188270ab6f6fc6f3295b5315224759e3d2e09db1"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -1483,31 +1482,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.17",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ url = { version = "2.5.7", features = ["serde"] }
 base64 = "0.22"
 
 # Form encoding with nested structure support
-serde_qs = "0.13"
+# serde_qs = "1.0.0-rc.3"
+serde_qs = { git = "https://github.com/Sheape/serde_qs.git", branch = "array-support" }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Unofficial Rust SDK for [PayRex](https://payrexhq.com)
   - [x] Payment Intents
   - [x] Payments
   - [x] Customers
-  - [ ] Billing Statements
+  - [x] Billing Statements
   - [x] Billing Statement Line Items
   - [ ] Checkout Sessions
   - [ ] Webhooks

--- a/src/http.rs
+++ b/src/http.rs
@@ -21,7 +21,7 @@ impl HttpClient {
 
         let credentials = format!("{}:", config.api_key());
         let encoded = general_purpose::STANDARD.encode(credentials.as_bytes());
-        let auth_value = format!("Basic {}", encoded);
+        let auth_value = format!("Basic {encoded}");
         headers.insert(
             header::AUTHORIZATION,
             header::HeaderValue::from_str(&auth_value)

--- a/src/resources/billing_statement_line_items.rs
+++ b/src/resources/billing_statement_line_items.rs
@@ -62,8 +62,7 @@ pub struct BillingStatementLineItem {
     pub billing_statement_id: BillingStatementId,
     pub livemode: bool,
     pub created_at: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<Timestamp>,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -161,7 +160,7 @@ mod tests {
             billing_statement_id: BillingStatementId::new("bstm_1"),
             livemode: false,
             created_at: Timestamp::from_unix(1_621_000_000),
-            updated_at: Some(Timestamp::from_unix(1_621_000_100)),
+            updated_at: Timestamp::from_unix(1_621_000_100),
         };
         let json = serde_json::to_value(&item).unwrap();
         assert_eq!(json["id"], "bstm_li_1");

--- a/src/resources/billing_statements.rs
+++ b/src/resources/billing_statements.rs
@@ -447,12 +447,11 @@ mod tests {
             payment_methods: vec![PaymentMethod::QRPh],
         };
 
-        let params =
-            CreateBillingStatement::new(CustomerId::new_unchecked("cus_001"), Currency::PHP)
-                .payment_settings(settings.clone())
-                .billing_details_collection("always")
-                .description("desc")
-                .metadata(metadata.clone());
+        let params = CreateBillingStatement::new(CustomerId::new("cus_001"), Currency::PHP)
+            .payment_settings(settings.clone())
+            .billing_details_collection("always")
+            .description("desc")
+            .metadata(metadata.clone());
 
         assert_eq!(params.customer_id.as_str(), "cus_001");
         assert_eq!(params.currency, Currency::PHP);
@@ -472,13 +471,15 @@ mod tests {
         };
 
         let params = UpdateBillingStatement::new()
-            .customer_id(CustomerId::new_unchecked("cus_002"))
+            .customer_id(CustomerId::new("cus_002"))
             .payment_settings(settings.clone())
+            .billing_details_collection("always")
             .description("upd")
             .metadata(metadata.clone());
 
         let json = serde_json::to_value(&params).unwrap();
         assert_eq!(json["customer_id"], "cus_002");
+        assert_eq!(json["billing_details_collection"], "always");
         assert_eq!(json["payment_settings"]["payment_methods"][0], "maya");
         assert_eq!(json["description"], "upd");
         assert_eq!(json["metadata"]["x"], "y");
@@ -508,7 +509,7 @@ mod tests {
             amount: 2000,
             billing_details_collection: Some("mandatory".to_string()),
             currency: Currency::PHP,
-            customer_id: CustomerId::new_unchecked("cus_999"),
+            customer_id: CustomerId::new("cus_999"),
             description: Some("Test invoice".to_string()),
             due_at: Some(Timestamp::from_unix(1_620_002_000)),
             finalized_at: None,

--- a/src/resources/customers.rs
+++ b/src/resources/customers.rs
@@ -67,6 +67,28 @@ pub struct Customer {
     pub updated_at: Timestamp,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OptionalCustomer {
+    pub id: CustomerId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub billing_statement_prefix: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<Currency>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    pub livemode: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_billing_statement_sequence_number: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<Timestamp>,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CreateCustomer {
     pub currency: Currency,

--- a/src/resources/customers.rs
+++ b/src/resources/customers.rs
@@ -302,7 +302,7 @@ mod tests {
         let mut metadata = Metadata::new();
         metadata.insert("order_id", "12345");
         let customer = Customer {
-            id: CustomerId::new_unchecked("cus_123456"),
+            id: CustomerId::new("cus_123456"),
             billing_statement_prefix: Some("PREF".to_string()),
             currency: Some(Currency::PHP),
             email: Some("test@example.com".to_string()),

--- a/src/resources/payment_intents.rs
+++ b/src/resources/payment_intents.rs
@@ -213,6 +213,109 @@ pub struct PaymentIntent {
     pub updated_at: Timestamp,
 }
 
+/// All fields in this struct are optional since fields nested under billing statements have
+/// optional fields. Hence, this should not be used for regular payment intent routes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OptionalPaymentIntent {
+    /// Unique identifier for the resource. The prefix is `pi_`.
+    pub id: PaymentIntentId,
+
+    /// The amount to be collected by the [`PaymentIntent`]. This is a positive integer that your
+    /// customer will pay in the smallest currency unit, cents. If the customer should pay ₱
+    /// 120.50, the amount of the [`PaymentIntent`] should be 12050.
+    ///
+    /// The minimum amount is ₱ 20 (2000 in cents) and the maximum amount is ₱ 59,999,999.99
+    /// (5999999999 in cents).
+    pub amount: Option<i64>,
+
+    /// The amount already collected by the [`PaymentIntent`]. This is a positive integer that your
+    /// customer paid in the smallest currency unit, cents. If the customer paid ₱ 120.50, the
+    /// `amount_received` of the [`PaymentIntent`] should be 12050.
+    ///
+    /// The minimum amount is ₱ 20 (2000 in cents) and the maximum amount is ₱ 59,999,999.99
+    /// (5999999999 in cents).
+    pub amount_received: Option<i64>,
+
+    /// The amount that can be captured by the [`PaymentIntent`]. This is a positive integer that your
+    /// customer authorized in the smallest currency unit, cents. If the customer authorized ₱
+    /// 120.50, the `amount_capturable` of the [`PaymentIntent`] should be 12050.
+    ///
+    /// The minimum amount is ₱ 20 (2000 in cents) and the maximum amount is ₱ 59,999,999.99
+    /// (5999999999 in cents).
+    pub amount_capturable: Option<i64>,
+
+    ///The client secret of this [`PaymentIntent`] used for client-side retrieval using a public API
+    ///key. The client secret can be used to complete a payment from your client application.
+    pub client_secret: Option<String>,
+
+    /// A three-letter ISO currency code in uppercase. As of the moment, we only support PHP.
+    pub currency: Option<Currency>,
+
+    /// An arbitrary string attached to the [`PaymentIntent`]. Useful reference when viewing paid
+    /// Payment from PayRex Dashboard.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// The value is `true` if the resource's mode is live or the value is `false` if the resource mode is test.
+    pub livemode: Option<bool>,
+
+    /// A set of key-value pairs attached to the [`PaymentIntent`] and the resources created by the
+    /// [`PaymentIntent`], e.g., Payment. This is useful for storing additional information about the
+    /// [`PaymentIntent`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
+
+    /// The `Payment` ID of the latest successful payment created by the [`PaymentIntent`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_payment: Option<String>,
+
+    /// The error returned in case of a failed payment attempt.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_payment_error: Option<PaymentError>,
+
+    /// The latest `PaymentMethod` ID of attached to the [`PaymentIntent`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_method_id: Option<String>,
+
+    /// The list of payment methods allowed to be processed by the [`PaymentIntent`].
+    pub payment_methods: Option<Vec<String>>,
+
+    /// A set of key-value pairs that can modify the behavior of the payment method attached to the
+    /// payment intent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_method_options: Option<PaymentMethodOptions>,
+
+    /// Text that appears on the customer's bank statement. This value overrides the merchant
+    /// account's trade name. For information about requirements, including the 22-character limit,
+    /// see the [Statement
+    /// Descriptor](https://docs.payrexhq.com/docs/guide/developer_handbook/statement_descriptor)
+    /// guide.
+    pub statement_descriptor: Option<String>,
+
+    /// The latest status of the [`PaymentIntent`]. Possible values are `awaiting_payment_method`, `awaiting_next_action`, `processing`, or `succeeded`.
+    pub status: Option<PaymentIntentStatus>,
+
+    /// If this attribute is present, it tells you what actions you need to take so that your
+    /// customer can make a payment using the selected method.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<NextAction>,
+
+    /// The URL where your customer will be redirected after completing the authentication if they
+    /// didn't exit or close their browser while authenticating.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub return_url: Option<String>,
+
+    /// The time by which the [`PaymentIntent`] must be captured to avoid being canceled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capture_before_at: Option<Timestamp>,
+
+    /// The time the resource was created and measured in seconds since the Unix epoch.
+    pub created_at: Option<Timestamp>,
+
+    /// The time the resource was updated and measured in seconds since the Unix epoch.
+    pub updated_at: Option<Timestamp>,
+}
+
 /// The status of a [`PaymentIntent`] describes the current state of the payment process.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -236,7 +339,7 @@ pub enum PaymentIntentStatus {
     RequiresCapture,
 
     /// The payment was cancelled.
-    Cancelled,
+    Canceled,
 
     /// The payment was successful.
     Succeeded,

--- a/src/resources/payouts.rs
+++ b/src/resources/payouts.rs
@@ -125,7 +125,7 @@ mod tests {
             bank_name: "Test Bank".to_string(),
         };
         let payout = Payout {
-            id: PayoutId::new_unchecked("po_123"),
+            id: PayoutId::new("po_123"),
             amount: 5000,
             destination: Some(dest.clone()),
             livemode: true,
@@ -150,10 +150,10 @@ mod tests {
     #[test]
     fn test_payout_transaction_serialization() {
         let tx = PayoutTransaction {
-            id: PayoutTransactionId::new_unchecked("pot_abc"),
+            id: PayoutTransactionId::new("pot_abc"),
             amount: 500,
             net_amount: 490,
-            transaction_id: PayoutTransactionId::new_unchecked("pot_xyz"),
+            transaction_id: PayoutTransactionId::new("pot_xyz"),
             transaction_type: PayoutTransactionType::Refund,
             created_at: Timestamp::from_unix(1_610_002_000),
             updated_at: None,

--- a/src/resources/refunds.rs
+++ b/src/resources/refunds.rs
@@ -175,7 +175,7 @@ mod tests {
         metadata.insert("key", "value");
 
         let refund = Refund {
-            id: RefundId::new_unchecked("ref_123"),
+            id: RefundId::new("re_123"),
             amount: 1000,
             currency: Currency::PHP,
             livemode: false,
@@ -183,7 +183,7 @@ mod tests {
             description: Some("desc".to_string()),
             reason: RefundReason::Fraudulent,
             remarks: Some("note".to_string()),
-            payment_id: PaymentId::new_unchecked("pay_456"),
+            payment_id: PaymentId::new("pay_456"),
             metadata: Some(metadata.clone()),
             created_at: Timestamp::from_unix(1_620_000_000),
             updated_at: Timestamp::from_unix(1_620_001_000),
@@ -191,7 +191,7 @@ mod tests {
 
         let json = serde_json::to_value(&refund).unwrap();
 
-        assert_eq!(json["id"], "ref_123");
+        assert_eq!(json["id"], "re_123");
         assert_eq!(json["amount"], 1000);
         assert_eq!(json["currency"], "PHP");
         assert_eq!(json["livemode"], false);
@@ -211,7 +211,7 @@ mod tests {
         metadata.insert("order", "1");
 
         let params = CreateRefund::new(
-            PaymentId::new_unchecked("pay_abc"),
+            PaymentId::new("pay_abc"),
             123,
             Currency::PHP,
             RefundReason::WrongProductReceived,

--- a/src/types/ids.rs
+++ b/src/types/ids.rs
@@ -77,7 +77,7 @@ define_id!(
 );
 define_id!(CheckoutSessionId, "cs_", "Checkout Session ID");
 define_id!(PaymentId, "pay_", "Payment ID");
-define_id!(RefundId, "ref_", "Refund ID");
+define_id!(RefundId, "re_", "Refund ID");
 define_id!(WebhookId, "wh_", "Webhook ID");
 define_id!(EventId, "evt_", "Event ID");
 define_id!(PayoutId, "po_", "Payout ID");


### PR DESCRIPTION
Checklist:
- [x] Add optional variant for customers and payments intents for nested billing statement response.
- [x] Use unindexed array for URL encoding in the request body.
- [x] Add unit test for serialization of create and update billing statements.
- [x] Add setters for create and update billing statements.
- [x] Update `README.md` to complete billing statements API.