### PR TITLE
feat: implement checkout sessions api

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Unofficial Rust SDK for [PayRex](https://payrexhq.com)
   - [x] Customers
   - [x] Billing Statements
   - [x] Billing Statement Line Items
-  - [ ] Checkout Sessions
+  - [x] Checkout Sessions
   - [ ] Webhooks
   - [ ] Events
   - [x] Refunds

--- a/src/resources/checkout_sessions.rs
+++ b/src/resources/checkout_sessions.rs
@@ -46,7 +46,7 @@ impl CheckoutSessions {
 pub struct CheckoutSession {
     pub id: CheckoutSessionId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub amount: Option<String>,
+    pub amount: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub customer_reference_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -95,8 +95,8 @@ pub struct CheckoutSessionLineItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<CheckoutSessionLineItemId>,
     pub name: String,
-    pub amount: String,
-    pub quantity: String,
+    pub amount: u64,
+    pub quantity: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -183,6 +183,30 @@ impl CreateCheckoutSession {
 
     pub fn metadata(mut self, metadata: Metadata) -> Self {
         self.metadata = Some(metadata);
+        self
+    }
+}
+
+impl CheckoutSessionLineItem {
+    #[must_use]
+    pub fn new(name: impl Into<String>, amount: u64, quantity: u64) -> Self {
+        Self {
+            id: None,
+            name: name.into(),
+            amount,
+            quantity,
+            description: None,
+            image: None,
+        }
+    }
+
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    pub fn image(mut self, image: impl Into<String>) -> Self {
+        self.image = Some(image.into());
         self
     }
 }

--- a/src/resources/payment_intents.rs
+++ b/src/resources/payment_intents.rs
@@ -187,7 +187,7 @@ pub struct PaymentIntent {
     /// see the [Statement
     /// Descriptor](https://docs.payrexhq.com/docs/guide/developer_handbook/statement_descriptor)
     /// guide.
-    pub statement_descriptor: String,
+    pub statement_descriptor: Option<String>,
 
     /// The latest status of the [`PaymentIntent`]. Possible values are `awaiting_payment_method`, `awaiting_next_action`, `processing`, or `succeeded`.
     pub status: PaymentIntentStatus,

--- a/src/types/ids.rs
+++ b/src/types/ids.rs
@@ -76,6 +76,11 @@ define_id!(
     "Billing Statement Line Item ID"
 );
 define_id!(CheckoutSessionId, "cs_", "Checkout Session ID");
+define_id!(
+    CheckoutSessionLineItemId,
+    "cs_li_",
+    "Checkout Session Line Item ID"
+);
 define_id!(PaymentId, "pay_", "Payment ID");
 define_id!(RefundId, "re_", "Refund ID");
 define_id!(WebhookId, "wh_", "Webhook ID");


### PR DESCRIPTION
Checklist:
- [x] Add structs and enums for creating checkout sessions
- [x] Add unit tests for serialization of structs and enums
- [x] Add unit tests for setters
- [x] Update `README.md` to complete checkout sessions API